### PR TITLE
Fix metadata unicode

### DIFF
--- a/lgr/parser/xml_serializer.py
+++ b/lgr/parser/xml_serializer.py
@@ -2,6 +2,7 @@
 """
 xml_serializer.py - Create an LGR XML compliant with draft-davies-idntables
 """
+from __future__ import unicode_literals
 
 import logging
 from lxml import etree
@@ -72,14 +73,14 @@ def _serialize_meta(lgr, meta):
         version_node = etree.SubElement(meta, 'version',
                                         version_attributes)
         if metadata.version.value is not None:
-            version_node.text = str(metadata.version.value)
+            version_node.text = "{}".format(metadata.version.value)
 
     for elem in ['date', 'validity_start', 'validity_end', 'unicode_version']:
         value = getattr(metadata, elem, None)
         if value is not None:
             # Python prevents using '-' in attribute names
             node = etree.SubElement(meta, elem.replace('_', '-'))
-            node.text = str(value)
+            node.text = "{}".format(value)
 
     for language in metadata.languages:
         etree.SubElement(meta, 'language').text = language

--- a/tests/unit/test_char.py
+++ b/tests/unit/test_char.py
@@ -528,7 +528,7 @@ class TestRepertoire(unittest.TestCase):
         self.cd.add_variant([0x002B], [0x002E])
         self.cd.add_variant([0x002E], [0x002B])
 
-        variant_sets = self.cd.get_variant_sets()
+        variant_sets = frozenset(self.cd.get_variant_sets())
         self.assertEqual(len(variant_sets), 2)
 
         self.assertSetEqual(variant_sets,

--- a/tests/unit/test_xml_serializer.py
+++ b/tests/unit/test_xml_serializer.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+test_xml_serializer - Unit testing of XML serializer
+"""
+from __future__ import unicode_literals
+
+import unittest
+
+from lxml import etree
+
+from lgr.core import LGR
+from lgr.metadata import Metadata, Version, Scope, Description
+from lgr.parser.xml_serializer import NSMAP, _serialize_meta
+
+
+class TestXmlSerializer(unittest.TestCase):
+
+    def setUp(self):
+        self.lgr = LGR()
+        self.root = etree.Element('lgr', nsmap=NSMAP)
+
+    def test_serialize_meta(self):
+        metadata = Metadata()
+        metadata.version = Version('1.0', comment='First version')
+        metadata.date = '2017-09-01'
+        metadata.description = Description('The LGR description', description_type='text/plain')
+        metadata.scopes = [Scope('.', scope_type='domain')]
+        self.lgr.metadata = metadata
+
+        meta_node = etree.SubElement(self.root, 'meta')
+
+        _serialize_meta(self.lgr, meta_node)
+
+        version = meta_node.find('version', namespaces=NSMAP)
+        self.assertEqual(version.text, '1.0')
+        # LXML can return strings as bytestring in python2...
+        # See https://mailman-mail5.webfaction.com/pipermail/lxml/2011-December/006239.html
+        self.assertEqual(u'' + version.get('comment'), 'First version')
+
+        date = meta_node.find('date', namespaces=NSMAP)
+        self.assertEqual(date.text, '2017-09-01')
+
+        description = meta_node.find('description', namespaces=NSMAP)
+        self.assertEqual(description.text, 'The LGR description')
+        self.assertEqual(description.get('type'), 'text/plain')
+
+        scopes = meta_node.findall('scope', namespaces=NSMAP)
+        self.assertEqual(len(scopes), 1)
+        self.assertEqual(scopes[0].text, '.')
+        self.assertEqual(scopes[0].get('type'), 'domain')
+
+    def test_serialize_meta_unicode(self):
+        metadata = Metadata()
+        metadata.version = Version('1.0 日本', comment='First version (はじめて)')
+        metadata.description = Description('The LGR description containing Unicode characters: ΘΞΠ', description_type='text/plain')
+        self.lgr.metadata = metadata
+
+        meta_node = etree.SubElement(self.root, 'meta')
+
+        _serialize_meta(self.lgr, meta_node)
+
+        version = meta_node.find('version', namespaces=NSMAP)
+        self.assertEqual(version.text, '1.0 日本')
+        self.assertEqual(version.get('comment'), 'First version (はじめて)')
+
+        description = meta_node.find('description', namespaces=NSMAP)
+        self.assertEqual(description.text, 'The LGR description containing Unicode characters: ΘΞΠ')
+        self.assertEqual(description.get('type'), 'text/plain')


### PR DESCRIPTION
Fix serialization of metadata that contain Unicode character (eg. version).
The serializer was incorrectly using str() instead of doing proper unicode handling.