### PR TITLE
Release 2.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog for lgr-core
 
+## 2.0.1 (2019-08-01)
+### Improvements
+- Mark out-of-script codepoints as warnings instead of errors (Fixes #15).
+### Fixes
+- Fix processing of contextual rule without anchor (Fixes #14).
+
 ## 2.0.0 (2018-09-06)
 ### New features
 - Support of Python 3. Compatibility with python2 is preserved for this release.

--- a/lgr/rule.py
+++ b/lgr/rule.py
@@ -133,10 +133,12 @@ class Rule(object):
                 rule_logger.debug('Not a parameterized context rule')
                 # Pattern is not a parameterized context-rule, so set index to 0
                 index = 0
-            # Format anchor - Can be a sequence.
-            # Use old-style formatting, see note in matcher.AnchorMatcher
-            pattern = pattern % {'anchor': ''.join(map(lambda c: '\\x{{{:X}}}'.format(c),
-                                                       anchor))}
+                anchor = None
+            else:
+                # Format anchor - Can be a sequence.
+                # Use old-style formatting, see note in matcher.AnchorMatcher
+                pattern = pattern % {'anchor': ''.join(map(lambda c: '\\x{{{:X}}}'.format(c),
+                                                           anchor))}
         rule_logger.debug("Pattern for rule %s: '%s'", self, pattern)
         try:
             regex = unicode_database.compile_regex(pattern)

--- a/lgr/validate/rebuild_lgr.py
+++ b/lgr/validate/rebuild_lgr.py
@@ -77,7 +77,7 @@ def rebuild_lgr(lgr, options):
                     range_ok = False
                 in_script, _ = lgr.cp_in_script([cp])
                 if not in_script:
-                    result['repertoire'].setdefault(char, {}).setdefault('errors', []).append(CharNotInScript(cp))
+                    result['repertoire'].setdefault(char, {}).setdefault('warnings', []).append(CharNotInScript(cp))
                     range_ok = False
 
             if not range_ok:
@@ -100,7 +100,7 @@ def rebuild_lgr(lgr, options):
 
         in_script, _ = lgr.cp_in_script(char.cp)
         if not in_script:
-            result['repertoire'].setdefault(char, {}).setdefault('errors', []).append(CharNotInScript(char.cp))
+            result['repertoire'].setdefault(char, {}).setdefault('warnings', []).append(CharNotInScript(char.cp))
         # Insert code point
         try:
             target_lgr.add_cp(char.cp,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class PyTest(TestCommand):
 
 setup(
     name="lgr-core",
-    version='2.0.0',
+    version='2.0.1',
     author='Viagénie and Wil Tan',
     author_email='support@viagenie.ca',
     description="API for manipulating Label Generation Rules",


### PR DESCRIPTION
Minor release fixing #14 and #15:
- Mark out-of-script codepoints as warnings instead of errors.
- Fix processing of contextual rule without anchor.