### PR TITLE
Add Changelog entries for the LGR validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 # Changelog for lgr-core
 
+### New features
+- Add support for LGR validation:
+    - Introduce the concept of test label. Each test label has a test (i.e. a predicate on LGR files) and a human readable description.
+    - Introduce the concept of policy. A policy maps test labels to values of either "IGNORED", "WARNING" or "ERROR".
+    - Assign test labels to already existing tests, e.g. "valid_unicode_version" and "metadata_language".
+    - Add new labelled tests, e.g. tests for the "validity-start" and "validity-end" elements.
+    - Add aggregation of test results in terms of successful test labels.
+    - Add a method to calculate the validation result based on policy and test results.
+    - Add an RFC 7940 validation tool.
+
 ## 2.0.0 (2018-09-06)
 ### New features
 - Support of Python 3. Compatibility with python2 is preserved for this release.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The `tools` directory contains some tools to exercise the library.
   and Unicode version.
 * `rfcXXXX_dump.py` parses inputs in RFC XXXX format, and generate an XML LGR.
 * `one_per_line_dump.py` parses input in the "one per line" format, and generate an XML LGR.
+* `rfc7940_validate.py` takes an LGR and checks it for compliance with RFC 7940.
 
 Other tools are available to manipulate LGR files and labels:
 * `lgr_annotate.py` takes an LGR and a list of labels and output


### PR DESCRIPTION
This is a proposal for changelog entries covering #12.
Also including drive-by change to add rfc7940_validate.py to the list of tools in the README.