### PR TITLE
Precalculate patterns in LGR rules for performance improvements

### DIFF
--- a/lgr/parser/xml_parser.py
+++ b/lgr/parser/xml_parser.py
@@ -367,6 +367,10 @@ class XMLParser(LGRParser):
 
         for child in elem:
             self._parse_rule_helper(child, rule)
+        
+        if self._unicode_database:
+            rule.precalculate_patterns(self._lgr.rules_lookup, self._lgr.classes_lookup,
+                                    self._unicode_database)
 
         return rule
 


### PR DESCRIPTION
I found that creating the patterns for rules was by far the most performance expensive part of label validation.  By precalculating these patterns when the LGR is loaded and parsed we see substantial improvements.  I also swapped to using stringio for slight string concat performance gains as well.