### PR TITLE
Use all char points when generating indexes instead of only the first

### DIFF
--- a/lgr/core.py
+++ b/lgr/core.py
@@ -1274,15 +1274,13 @@ class LGR(object):
         for char in chars:
             logger.debug('Char CP: %s', format_cp(char.cp))
             # Index: smallest id of the char and its variants
-            # FIXME: This index algorithm has some problems when dealing with sequences and should be fixed
-            ids = [char.as_index()]
+            ids = [char.cp]
             for var in char.get_variants():
-                var_char = self.repertoire.get_char(var.cp)
-                logger.debug('Variant CP: %r', var_char)
-                ids.append(var_char.as_index())
-            logger.debug('List of variant ids: %s', ids)
+                ids.append(var.cp)
 
-            index_label.append(min(ids))
+            # Find the minimum id, handling both single values and tuples
+            min_id = min(ids, key=lambda x: x if isinstance(x, int) else min(x))
+            index_label += min_id
 
         logger.debug("Index label: '%s'", index_label)
 


### PR DESCRIPTION
When generating indexes for a given label we currently only take into account the first codepoint of any given char.  This can cause issues.  For example the common LGR currently provided by ICANN contains:
```
    <char cp="0073 0073" ref="118" comment="Sequence added for variant mapping">
      <var cp="00DF" type="blocked" ref="118" comment="IDNA2003 Compatibility" />
      <var cp="03B2" type="blocked" ref="118" />
    </char>
```
This is meant to mark "ß" as a variant of "ss" but because of the current index generation logic any label with "ss" will return an index containing only "s".  IE "sharpness" -> "sharpnes".  I don't think this is intended behavior and will cause a lot of collisions.

This PR seems to resolve the issue for me ("sharpness" -> "sharpnes", "teßt" -> "tesst") but more rigorous testing may be needed.