### PR TITLE
Rework index computation

### DIFF
--- a/lgr/core.py
+++ b/lgr/core.py
@@ -1279,7 +1279,7 @@ class LGR(object):
                 variant_number *= len(vars_excl_reflexive(char)) + 1  # Take into account original code point
         return variant_number
 
-    def generate_index_label(self, label):
+    def generate_index_label(self, label, max_recursion=0):
         """
         Generate the "index label" of a given label.
 
@@ -1295,6 +1295,7 @@ class LGR(object):
         Pre-requires: Symmetric and transitive LGR.
 
         :param label: The label to compute the disposition of, as a sequence of code points.
+        :param max_recursion: Maximum number of recursions to perform.
 
         :return: The index label, as a list and the index computed with minimum code point algorithm if required.
         :raises NotInLgr: If the label is not in the LGR
@@ -1324,6 +1325,18 @@ class LGR(object):
 
         index_label = min(indexes)
         logger.debug("Index label: '%s'", index_label)
+
+        # max_recursion should be 0 to be compliant with the Index Label Calculation reference
+        if max_recursion > 0 and index_label != label:
+            # if the LGR is not well-built, you might have an index_label that when run against the
+            # same computation ends up with a different index label
+            old_index_label = tuple(index_label)
+            try:
+                index_label = self.generate_index_label(index_label, max_recursion=max_recursion - 1)
+                if index_label != old_index_label:
+                    logger.warning("Index label '%s' changed to '%s' after a new itertion", old_index_label, index_label)
+            except Exception:
+                pass
 
         return tuple(index_label)
 

--- a/lgr/rule.py
+++ b/lgr/rule.py
@@ -94,9 +94,9 @@ class Rule(object):
         pattern_io = io.StringIO()
         for m in self.children:
             pattern_io.write(m.get_pattern(rules_lookup,
-                                        classes_lookup,
-                                        unicode_database,
-                                        is_look_behind))
+                                           classes_lookup,
+                                           unicode_database,
+                                           is_look_behind))
 
         self._pattern_cache[cache_key] = pattern_io.getvalue()
         return pattern_io.getvalue()

--- a/lgr/test_utils/unicode_database_mock.py
+++ b/lgr/test_utils/unicode_database_mock.py
@@ -46,6 +46,8 @@ class UnicodeDatabaseMock(UnicodeDatabase):
 
     def get_script(self, cp, alpha4=False):
         from lgr.test_utils.unidb_get_script_mock import script
+        if isinstance(cp, str):
+            cp = ord(cp)
         return script(cp)
 
     def get_script_extensions(self, cp, alpha4=False):

--- a/lgr/test_utils/unicode_database_mock.py
+++ b/lgr/test_utils/unicode_database_mock.py
@@ -45,10 +45,13 @@ class UnicodeDatabaseMock(UnicodeDatabase):
         raise NotImplementedError
 
     def get_script(self, cp, alpha4=False):
-        from lgr.test_utils.unidb_get_script_mock import script
+        from lgr.test_utils.unidb_get_script_mock import script, script_to_alpha4
         if isinstance(cp, str):
             cp = ord(cp)
-        return script(cp)
+        cp_script = script(cp)
+        if alpha4:
+            cp_script = script_to_alpha4.get(cp_script, cp_script)
+        return cp_script
 
     def get_script_extensions(self, cp, alpha4=False):
         raise NotImplementedError

--- a/lgr/test_utils/unidb_get_script_mock.py
+++ b/lgr/test_utils/unidb_get_script_mock.py
@@ -550,6 +550,36 @@ script_data = {
 (0xe0020,0xe007f,0,13), (0xe0100,0xe01ef,40,23)
 ]}
 
+script_to_alpha4 = {
+    'Arabic': 'Arab',
+    'Armenian': 'Armn',
+    'Bengali': 'Beng',
+    'Cyrillic': 'Cyrl',
+    'Devanagari': 'Deva',
+    'Ethiopic': 'Ethi',
+    'Georgian': 'Geor',
+    'Greek': 'Grek',
+    'Gujarati': 'Gujr',
+    'Gurmukhi': 'Guru',
+    'Hebrew': 'Hebr',
+    'Katakana': 'Kana',
+    'Hiragana': 'Hira',
+    'Kannada': 'Knda',
+    'Khmer': 'Khmr',
+    'Han': 'Hani',
+    'Hangul': 'Hang',
+    'Lao': 'Laoo',
+    'Latin': 'Latn',
+    'Malayalam': 'Mlym',
+    'Myanmar': 'Mymr',
+    'Oriya': 'Orya',
+    'Sinhala': 'Sinh',
+    'Tamil': 'Taml',
+    'Telugu': 'Telu',
+    'Thai': 'Thai',
+    'Thaana': 'Thaa',
+}
+
 def script(c):
     """ For the unicode character c in hex return its Scriptname. """
     l = 0

--- a/lgr/tools/idn_review/whole_label_evaluation_rules.py
+++ b/lgr/tools/idn_review/whole_label_evaluation_rules.py
@@ -398,10 +398,10 @@ class WholeLabelEvaluationRulesCheck:
             'exists': result,
         }
 
+    # TODO move method in core.py
     def check_label_cp_in_repertoire(self, label):
-        i = 0
         result = False
-        cp = label[i]
+        cp = label[0]
 
         try:
             char_list = self.idn_table.repertoire.get_chars_from_prefix(cp)
@@ -410,12 +410,12 @@ class WholeLabelEvaluationRulesCheck:
 
         for char in char_list:
             if isinstance(char, CharSequence):
-                if not char.is_prefix_of(label[i:]):
+                if not char.is_prefix_of(label):
                     continue
                 else:
-                    result |= self.check_label_cp_in_repertoire(label[i + len(char):])
+                    result |= self.check_label_cp_in_repertoire(label[len(char):])
             elif len(label) > 1:
-                result |= self.check_label_cp_in_repertoire(label[i + 1:])
+                result |= self.check_label_cp_in_repertoire(label[1:])
             else:
                 return True
 

--- a/lgr/utils.py
+++ b/lgr/utils.py
@@ -204,14 +204,6 @@ def let_user_choose(first, second, separator='|'):
         return first
     return '{0!s}{1!s}{2!s}'.format(first, separator, second)
 
-
-if __name__ == "__main__":
-    import doctest
-
-    logger.addHandler(logging.NullHandler())
-    doctest.testmod()
-
-
 def tag_to_language_script(tag, use_suppress_script=False):
     if '-' in tag:
         # replace 3 char language isocode by 2 char isocode
@@ -252,3 +244,10 @@ def is_idna_valid_cp_or_sequence(cp_or_sequence, udata, check_all=False):
             if not check_all:
                 return False, all_invalid
     return len(all_invalid) == 0, all_invalid
+
+
+if __name__ == "__main__":
+    import doctest
+
+    logger.addHandler(logging.NullHandler())
+    doctest.testmod()

--- a/tests/unit/test_lgr_core.py
+++ b/tests/unit/test_lgr_core.py
@@ -811,7 +811,29 @@ class TestLGRCore(unittest.TestCase):
         self.assertEqual((0x062, 0x006C, 0x0075, 0x0065),
                          self.lgr.generate_index_label([0x044B, 0x045F, 0x0435]))
 
+    def test_generate_index_label_overlap_recurse(self):
+        self.lgr.add_cp([0x0062])  # a
+        self.lgr.add_cp([0x0062, 0x006C])  # bl
+        self.lgr.add_cp([0x0065])  # e
+        self.lgr.add_cp([0x0069])  # i
+        self.lgr.add_cp([0x006C])  # l
+        self.lgr.add_cp([0x0075])  # u
+        self.lgr.add_cp([0x0435])  # е (Cyrillic)
+        self.lgr.add_cp([0x044B])  # ы (Cyrillic)
+        self.lgr.add_cp([0x045F])  # џ (Cyrillic)
 
+        self.lgr.add_variant([0x0062, 0x006C], [0x044B])
+        self.lgr.add_variant([0x044B], [0x0062, 0x006C])
+        self.lgr.add_variant([0x0065], [0x0435])
+        self.lgr.add_variant([0x0435], [0x0065])
+        self.lgr.add_variant([0x0069], [0x006C])
+        self.lgr.add_variant([0x006C], [0x0069])
+        self.lgr.add_variant([0x0075], [0x045F])
+        self.lgr.add_variant([0x045F], [0x0075])
+
+        # one more recursion will make the index label right
+        self.assertEqual((0x062, 0x0069, 0x0075, 0x0065),
+                         self.lgr.generate_index_label([0x044B, 0x045F, 0x0435], max_recursion=1))
 
 
 

--- a/tests/unit/tools/test_utils.py
+++ b/tests/unit/tools/test_utils.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from tools.utils import get_rz_label_script
+from lgr.tools.utils import get_rz_label_script
 
 
 class TestGetRZLabelScript(TestCase):

--- a/tools/lgr_collision.py
+++ b/tools/lgr_collision.py
@@ -20,7 +20,7 @@ def compute_label_index(lgr, label):
 
 
 def find_variants_to_block(lgr, label_ref, label):
-    var_ref = [var for (var, _, _) in lgr._generate_label_variants(label_ref)]
+    var_ref = [var for (var, _, _, _) in lgr._generate_label_variants(label_ref)]
 
     for (variant_cp, disp, _, _, disp_set, _) in lgr.compute_label_disposition(label):
         if variant_cp in var_ref:


### PR DESCRIPTION
Rewrite the index label calculation based on the upcoming  Root Zone Label Generation Rules (RZ LGR-6)  Overview and Summary.

The branch was initially not meant for this, but ended up being useful for the index computation, so a few other updates are shipped within.
