### PR TITLE
Add method to compute a variant disposition without enumerating others

### DIFF
--- a/lgr/core.py
+++ b/lgr/core.py
@@ -8,6 +8,7 @@ import collections
 import logging
 from collections import OrderedDict
 from io import StringIO
+from typing import Optional, Iterator
 
 from lgr.action import Action
 from lgr.char import CharBase, CharSequence, Repertoire
@@ -75,9 +76,12 @@ MAX_NUMBER_GENERATED_VARIANTS = 1000
 # From RFC1035, 2.3.4 Size limits
 PROTOCOL_LABEL_MAX_LENGTH = 63
 
+Label = tuple[int] | list[int]
+InvalidLabelParts = list[tuple[int, None | list[str]]] | None
+LabelPartition = list[CharBase]
 
 
-class LGR(object):
+class LGR:
     """
     The main LGR object.
     """
@@ -1019,8 +1023,8 @@ class LGR(object):
         self.classes_lookup[cls.name] = cls
         self.classes.append(cls.name)
 
-    # TODO get rid of generate_chars and always return them
-    def test_label_eligible(self, label, is_variant=False, collect_log=True, generate_chars=False):
+    def test_label_eligible(self, label: Label, is_variant=False, collect_log=True) -> tuple[
+        bool, Label, InvalidLabelParts, str, int, str, LabelPartition]:
         """
         Test label eligibility against an LGR.
 
@@ -1030,7 +1034,7 @@ class LGR(object):
         :param label: The label to test, as an array of codepoints.
         :param is_variant: Whether we are testing a variant label eligibility.
         :param collect_log: If False, do not collect rule processing log.
-        :return: (result, label_parts, label_invalid_parts, disposition, action_idx, log)
+        :return: (result, label_parts, label_invalid_parts, disposition, action_idx, log, chars)
                  with:
 
                      - result: True if the label is eligible according to the LGR,
@@ -1043,7 +1047,7 @@ class LGR(object):
                                    -1 if the label is not in the LGR.
                      - log: Log of the disposition computation,
                             empty if collect_log is False
-                     - chars: List of the LGR chars included in label (as a CharBase class) if generate_chars is True
+                     - chars: List of the LGR chars included in label (as a CharBase class) (TODO: it returns only one chars partition)
         """
         if not label:
             raise LGRApiInvalidParameter('label')
@@ -1061,10 +1065,7 @@ class LGR(object):
             rule_logger.error("Label '%s' is not in the LGR", format_cp(label))
             if collect_log:
                 rule_logger.removeHandler(ch)
-            if generate_chars:
-                return False, label_parts, label_invalid_parts, INVALID_DISPOSITION, -1, log_output.getvalue(), chars
-            else:
-                return False, label_parts, label_invalid_parts, INVALID_DISPOSITION, -1, log_output.getvalue()
+            return False, label_parts, label_invalid_parts, INVALID_DISPOSITION, -1, log_output.getvalue(), chars
 
         # Compute label disposition by analyzing reflexive mappings
         (disposition, action_idx) = self._test_label_disposition(label, apply_reflexive_mapping=not is_variant)
@@ -1073,26 +1074,23 @@ class LGR(object):
                               "triggered by action #%d", action_idx)
             if collect_log:
                 rule_logger.removeHandler(ch)
-            if generate_chars:
-                return False, [], [], disposition, action_idx, log_output.getvalue(), chars
-            else:
-                return False, [], [], disposition, action_idx, log_output.getvalue()
+            return False, [], [], disposition, action_idx, log_output.getvalue(), chars
 
         if collect_log:
             rule_logger.removeHandler(ch)
-        if generate_chars:
-            return True, label, [], disposition, action_idx, log_output.getvalue(), chars
-        else:
-            return True, label, [], disposition, action_idx, log_output.getvalue()
+        return True, label, [], disposition, action_idx, log_output.getvalue(), chars
 
-    def compute_label_disposition(self, label, include_invalid=False,
+    def compute_label_disposition(self, label: tuple[int], include_invalid=False,
                                   collect_log=True, hide_mixed_script_variants=False,
-                                  with_labels=None, generate_chars=False):
+                                  with_labels=None, generate_chars=False) -> Iterator[tuple[
+        tuple[int], str | None, InvalidLabelParts, int, set[str] | None, str, Optional[LabelPartition]]]:
         """
         Given a label, compute its disposition and its variants.
 
         The original label (unpermuted or with reflexive variants) will be the
         last label returned.
+
+        When generate_chars is True, you may get duplicated variants with different partitions.
 
         :param label: The label to compute the disposition of,
                       as a sequence of code points.
@@ -1103,6 +1101,7 @@ class LGR(object):
         :param collect_log: If False, do not collect rule processing log.
         :param hide_mixed_script_variants: Whether we hide mixed scripts variants.
         :param with_labels: Compute disposition of selected labels only, all if None
+        :param generate_chars: Whether we should return the char of the variants.
         :return: Generator of (variant_cp, variant_invalid_parts, disp, action_idx, disp_set, log[, chars])
                  with:
                      - variant_cp: The code point sequence of a variant.
@@ -1144,37 +1143,11 @@ class LGR(object):
             if not generate_chars and variant_cp in already_handled:
                 continue
 
-            # TODO we may have another method that doesn't retrieve all variants then loop to
-            # find with_labels, but only loop on the labels in with_labels, and ensure they
-            # share the same index for sanity checking
             if with_labels and variant_cp not in with_labels:
                 continue
             already_handled.add(variant_cp)
-            # Configure log system to redirect logs to local attribute
-            log_output = StringIO()
-            if collect_log:
-                ch = logging.StreamHandler(log_output)
-                ch.setLevel(logging.DEBUG)
-                rule_logger.addHandler(ch)
-
-            # 8.3.  Determining a Disposition for a Label or Variant Label
-            # Step 1
-            eligible, _, variant_invalid_parts, _, idx, _ = self.test_label_eligible(variant_cp,
-                                                                                     is_variant=variant_cp != label,
-                                                                                     collect_log=collect_log)
-            if not eligible:
-                variant_disp = INVALID_DISPOSITION
-            else:
-                # 8.3.  Determining a Disposition for a Label or Variant Label
-                # Step 2 - 3
-                (variant_disp, idx) = self._apply_actions(variant_cp,
-                                                          disp_set,
-                                                          only_variants)
-
-                if variant_disp is None:
-                    # 8.3.  Determining a Disposition for a Label or Variant Label
-                    # Step 4
-                    variant_disp = DEFAULT_DISPOSITION
+            variant_disp, variant_invalid_parts, idx, log_output = self._check_label_disp(label, variant_cp, disp_set,
+                                                                                          only_variants, collect_log)
 
             if (variant_disp != INVALID_DISPOSITION) or include_invalid:
                 if variant_cp == label:
@@ -1189,22 +1162,47 @@ class LGR(object):
                     else:
                         yield variant_cp, variant_disp, variant_invalid_parts, idx, disp_set, log_output.getvalue()
 
-            if collect_log:
-                rule_logger.removeHandler(ch)
 
         if not original_label:
-            # TODO: already computed since label MUST be eligible
             rule_logger.debug('Add original label')
+            _, _, _, disposition, action_idx, log, chars = self.test_label_eligible(label, collect_log=collect_log)
             if generate_chars:
-                _, _, _, disposition, action_idx, log, chars = self.test_label_eligible(label, collect_log=collect_log,
-                                                                                        generate_chars=generate_chars)
                 original_label = label, disposition, None, action_idx, set(), log, chars
             else:
-                _, _, _, disposition, action_idx, log = self.test_label_eligible(label, collect_log=collect_log,
-                                                                                 generate_chars=generate_chars)
                 original_label = label, disposition, None, action_idx, set(), log
 
         yield original_label
+
+    def _check_label_disp(self, label: Label, variant_cp: Label, disp_set: set[str], only_variants: bool,
+                          collect_log: bool) -> tuple[str | None, InvalidLabelParts, int, StringIO]:
+        # Configure log system to redirect logs to local attribute
+        log_output = StringIO()
+        if collect_log:
+            ch = logging.StreamHandler(log_output)
+            ch.setLevel(logging.DEBUG)
+            rule_logger.addHandler(ch)
+
+        # 8.3.  Determining a Disposition for a Label or Variant Label
+        # Step 1
+        # TODO we should test_label_eligible with chars as input here since we have a partition in the loop above
+        eligible, _, variant_invalid_parts, _, idx, _, _ = self.test_label_eligible(variant_cp,
+                                                                                    is_variant=variant_cp != label,
+                                                                                    collect_log=collect_log)
+        if not eligible:
+            variant_disp = INVALID_DISPOSITION
+        else:
+            # 8.3.  Determining a Disposition for a Label or Variant Label
+            # Step 2 - 3
+            (variant_disp, idx) = self._apply_actions(variant_cp, disp_set, only_variants)
+
+            if variant_disp is None:
+                # 8.3.  Determining a Disposition for a Label or Variant Label
+                # Step 4
+                variant_disp = DEFAULT_DISPOSITION
+
+        if collect_log:
+            rule_logger.removeHandler(ch)
+        return variant_disp, variant_invalid_parts, idx, log_output
 
     def compute_label_disposition_summary(self, label, include_invalid=False, hide_mixed_script_variants=False):
         """
@@ -1239,7 +1237,9 @@ class LGR(object):
                                        in label_dispositions])
         return summary, label_dispositions
 
-    def compute_variant_disposition(self, label, variant, collect_log=True):
+    def compute_variant_disposition(self, label: Label, variant: tuple[int],
+                                    collect_log: bool = False) -> Iterator[tuple[
+        tuple[int], str, InvalidLabelParts, int, set[str], str, LabelPartition]]:
         """
         Given a label and its variant, compute the variant dispositions.
 
@@ -1282,31 +1282,11 @@ class LGR(object):
         variant_set = self._generate_variant_dispositions(label, variant)
 
         for (variant_cp, disp_set, only_variants, chars) in variant_set:
-            # Configure log system to redirect logs to local attribute
-            log_output = StringIO()
-            if collect_log:
-                ch = logging.StreamHandler(log_output)
-                ch.setLevel(logging.DEBUG)
-                rule_logger.addHandler(ch)
-
-            eligible, _, variant_invalid_parts, _, idx, _ = self.test_label_eligible(variant_cp,
-                                                                                     is_variant=True,
-                                                                                     collect_log=collect_log)
-            if not eligible:
-                variant_disp = INVALID_DISPOSITION
-            else:
-                (variant_disp, idx) = self._apply_actions(variant_cp,
-                                                          disp_set,
-                                                          only_variants)
-
-                if variant_disp is None:
-                    variant_disp = DEFAULT_DISPOSITION
-
-            if (variant_disp != INVALID_DISPOSITION):
+            variant_disp, variant_invalid_parts, idx, log_output = self._check_label_disp(label, variant_cp, disp_set,
+                                                                                          only_variants, collect_log)
+            if variant_disp != INVALID_DISPOSITION:
                 yield variant_cp, variant_disp, variant_invalid_parts, idx, disp_set, log_output.getvalue(), chars
 
-            if collect_log:
-                rule_logger.removeHandler(ch)
 
     def estimate_variant_number(self, label, hide_mixed_script_variants=False):
         """
@@ -1346,7 +1326,7 @@ class LGR(object):
                 variant_number *= len(vars_excl_reflexive(char)) + 1  # Take into account original code point
         return variant_number
 
-    def generate_index_label(self, label, max_recursion=0):
+    def generate_index_label(self, label: Label, max_recursion=0) -> tuple[int]:
         """
         Generate the "index label" of a given label.
 
@@ -1412,7 +1392,7 @@ class LGR(object):
 
         return tuple(index_label)
 
-    def _generate_index_label_on_partition(self, chars):
+    def _generate_index_label_on_partition(self, chars: LabelPartition) -> tuple[int]:
         """
         Generate the "index label" for a list of chars.
 
@@ -1449,7 +1429,7 @@ class LGR(object):
 
         return tuple(index_label)
 
-    def _generate_label_partitions(self, label, prefix=None) -> list[list[CharBase]]:
+    def _generate_label_partitions(self, label: Label, prefix=None) -> list[LabelPartition]:
         """
         Retrieve all partitions of a given label.
 
@@ -1576,14 +1556,14 @@ class LGR(object):
         logger.debug('Populate LGR variants')
         return populate_lgr(self)
 
-    def _test_preliminary_eligibility(self, label: list[int]) -> tuple[bool, list[tuple[int]], list, list[CharBase]]:
+    def _test_preliminary_eligibility(self, label: Label) -> tuple[
+        bool, list[int], InvalidLabelParts, LabelPartition]:
         """
         Test label eligibility against an LGR.
 
         A label is eligible if each of its code point is in the LGR.
 
         :param label: The label to test, as an array of codepoints.
-        :param generate_chars: Return list of corresponding char objects.
         :return: (result, label_parts, label_invalid_parts, chars), with:
 
                  * result: True if the label is eligible according to the LGR,
@@ -1603,7 +1583,8 @@ class LGR(object):
         else:
             return self._retrieve_invalid_label_parts(label)
 
-    def _retrieve_valid_label_parts(self, partitions: list[list[CharBase]]) -> tuple[bool, list[tuple[int]], list, list[CharBase]]:
+    def _retrieve_valid_label_parts(self, partitions: list[LabelPartition]) -> tuple[
+        bool, list[int], list, LabelPartition]:
         label_parts = []
         chars = []
 
@@ -1613,7 +1594,8 @@ class LGR(object):
             chars.append(char)
         return True, label_parts, [], chars
 
-    def _retrieve_invalid_label_parts(self, label) -> tuple[bool, list[tuple[int]], list, list[CharBase]]:
+    def _retrieve_invalid_label_parts(self, label) -> tuple[
+        bool, list[int], InvalidLabelParts, LabelPartition]:
         """
         Extract valid and invalid parts from an invalid label.
 
@@ -1688,12 +1670,14 @@ class LGR(object):
 
         return result, label_parts, label_invalid_parts, chars if result else []
 
-    def _test_label_disposition(self, label, apply_reflexive_mapping=True):
+    def _test_label_disposition(self, label: Label, apply_reflexive_mapping=True) -> tuple[str | None, int]:
         """
         Compute the final disposition of a label.
 
         This function iterates through the reflexive variants of a label,
         collects the disposition types, and apply the defined actions.
+
+        TODO: this computes the disposition for one partition
 
         :param label: Input label to test.
                       Must have passed the 'preliminary' eligibility test.
@@ -1770,7 +1754,8 @@ class LGR(object):
 
         return self._apply_actions(label, disp_set, only_variants)
 
-    def _get_prefix_list(self, label, label_prefix):
+    # TODO refactors other with this (see where we use get_chars_from_prefix)
+    def _get_prefix_list(self, label: Label, label_prefix: tuple[int]) -> LabelPartition:
         """
         Generate the list of characters with same prefix.
 
@@ -1783,8 +1768,7 @@ class LGR(object):
         :return: list of valid prefix characters.
         """
         prefix_list = []
-        for prefix in self.repertoire.get_chars_from_prefix(label[0],
-                                                            only_variants=True):
+        for prefix in self.repertoire.get_chars_from_prefix(label[0]):
             # Ensure prefix is valid for label
             if not prefix.is_prefix_of(label):
                 continue
@@ -1796,9 +1780,7 @@ class LGR(object):
             prefixed_label = label_prefix + prefix.cp + tuple(label[len(prefix):])
 
             # Test when/not-when rules on prefixed_label
-            if not self._test_context_rules(prefix,
-                                            prefixed_label,
-                                            len(label_prefix)):
+            if not self._test_context_rules(prefix, prefixed_label, len(label_prefix)):
                 rule_logger.debug('No context rule')
                 continue
 
@@ -1806,11 +1788,12 @@ class LGR(object):
 
         return prefix_list
 
-    def _generate_label_variants(self, label,
+    def _generate_label_variants(self, label: Label,
                                  orig_label=None, label_prefix=None,
                                  has_variant=False,
                                  mixed_script_filter: BaseMixedScriptsVariantFilter = None,
-                                 hide_mixed_script_variants=False):
+                                 hide_mixed_script_variants=False) -> Iterator[
+        tuple[tuple[int], set[str], bool, LabelPartition]]:
         """
         Generate a list of all the variants for a given label.
 
@@ -1863,34 +1846,8 @@ class LGR(object):
         if hide_mixed_script_variants and not mixed_script_filter:
             mixed_script_filter = MixedScriptsVariantFilter(label, self.repertoire, unidb=self._unicode_database)
 
-        try:
-            same_prefix = self._get_prefix_list(label, label_prefix)
-        except NotInLGR:
-            rule_logger.debug('Char is not in LGR,'
-                              'assume we are handling a sequence')
-            # This is not an error: we might be handling code points
-            # belonging to a sequence which is being decomposed by the
-            # variant generation process.
-            # The sequence is part of the LGR,
-            # but not the individual code points.
-            same_prefix = []
-        else:
-            if len(same_prefix) == 0:
-                # No code point in LGR with variants,
-                # stick to first one found (longest in label)
-                for cp in self.repertoire.get_chars_from_prefix(label[0]):
-                    if cp.is_prefix_of(label):
-                        same_prefix = [cp]
-                        break
-
-        for char in [ch for ch in same_prefix if isinstance(ch, CharSequence)]:
-            # char is a sequence, if first code point of the sequence is in the LGR we need to consider it
-            for cp in self.repertoire.get_chars_from_prefix(label[0]):
-                if len(cp) < len(char) and cp.is_prefix_of(label):
-                    same_prefix.append(cp)
-
         # Iterate through characters matching the start of the label
-        for char in same_prefix:
+        for char in self._list_label_prefixes(label, label_prefix):
             rule_logger.debug("Char %s", format_cp(char.cp))
 
             has_reflexive_mapping = False
@@ -1973,26 +1930,40 @@ class LGR(object):
                 for (char_perm, disp, is_variant, chars) in char_perms:
                     yield char_perm.cp, disp, is_variant, [char_perm]
 
-    def _generate_variant_dispositions(self, label, variant, label_prefix=None, has_variant=False):
+    def _list_label_prefixes(self, label: Label, label_prefix: tuple[int]) -> LabelPartition:
+        try:
+            same_prefix = self._get_prefix_list(label, label_prefix)
+        except NotInLGR:
+            rule_logger.debug('Char is not in LGR,'
+                              'assume we are handling a sequence')
+            # This is not an error: we might be handling code points
+            # belonging to a sequence which is being decomposed by the
+            # variant generation process.
+            # The sequence is part of the LGR,
+            # but not the individual code points.
+            same_prefix = []
+        else:
+            if len(same_prefix) == 0:
+                # No code point in LGR with variants,
+                # stick to first one found (longest in label)
+                for cp in self.repertoire.get_chars_from_prefix(label[0]):
+                    if cp.is_prefix_of(label):
+                        same_prefix = [cp]
+                        break
+
+        return same_prefix
+
+    def _generate_variant_dispositions(self, label: Label, variant: Label, label_prefix=None) -> \
+            Iterator[tuple[tuple[int], set[str], bool, LabelPartition]]:
         """
-        Generate a list of all the variants for a given label.
+        Generate dispositions for a variant of a given label
 
-        Takes a label as input, and output the _variants_ of the label.
-        If there is no code point with at least one variant defined,
-        then the output is empty.
-        Output may contain the reflexive variant of a label, if any reflexive
-        mapping is defined and valid in the label context.
+        Takes a label and variant as input, and output the dispositions of the variant.
+        If variant is not a variant of the input label, then the output is empty.
 
-        :param label: The label to generate the variants of,
-                      as a sequence of code points.
-        :param orig_label: The full original label,
-                           used when evaluating when/not-when rules
-                           (used for recursion).
+        :param label: The primary label as a sequence of code points.
+        :param variant: The variant of the primary label as a sequence of code points
         :param label_prefix: The prefix of the label (used for recursion).
-        :param has_variant: True if the prefix has at least one variant
-                            (used for recursion).
-        :param mixed_script_filter: Filter for mixed script (used for recursion).
-        :param hide_mixed_script_variants: Whether we hide mixed scripts variants.
         :return: A generator of (variant_cp, variant_disp, only_variants, chars),
                  with:
 
@@ -2017,43 +1988,16 @@ class LGR(object):
         label = tuple(label)
         variant = tuple(variant)
 
-        try:
-            same_prefix = self._get_prefix_list(label, label_prefix)
-        except NotInLGR:
-            rule_logger.debug('Char is not in LGR,'
-                              'assume we are handling a sequence')
-            # This is not an error: we might be handling code points
-            # belonging to a sequence which is being decomposed by the
-            # variant generation process.
-            # The sequence is part of the LGR,
-            # but not the individual code points.
-            same_prefix = []
-        else:
-            if len(same_prefix) == 0:
-                # No code point in LGR with variants,
-                # stick to first one found (longest in label)
-                for cp in self.repertoire.get_chars_from_prefix(label[0]):
-                    if cp.is_prefix_of(label):
-                        same_prefix = [cp]
-                        break
-
-        for char in [ch for ch in same_prefix if isinstance(ch, CharSequence)]:
-            # char is a sequence, if first code point of the sequence is in the LGR we need to consider it
-            for cp in self.repertoire.get_chars_from_prefix(label[0]):
-                if len(cp) < len(char) and cp.is_prefix_of(label):
-                    same_prefix.append(cp)
-
         # Iterate through characters matching the start of the label
-        for char in same_prefix:
+        for char in self._list_label_prefixes(label, label_prefix):
             rule_logger.debug("Char %s", format_cp(char.cp))
 
-            if char.is_prefix_of(variant):
-                # variant and char have same characters
+            if char.is_prefix_of(variant) and not char.get_variant(char.cp):
+                # variant and char have same characters, and variant has no reflexive mapping
                 if len(label) > len(char):
                     for (perm_cps, perm_disp, _, perm_chars) in \
                             self._generate_variant_dispositions(label[len(char):], variant[len(char):],
-                                                                label_prefix=label_prefix + label[:len(char)],
-                                                                has_variant=has_variant):
+                                                                label_prefix=label_prefix + label[:len(char)]):
                         yield char.cp + perm_cps, perm_disp, False, [char] + perm_chars
                 else:
                     yield char.cp, frozenset(), False, [char]
@@ -2065,7 +2009,7 @@ class LGR(object):
                         continue
                 except NotInLGR:
                     # LGR is not valid
-                    rule_logger.error("Invalid LGR: variant %s is not par of repertoire", format_cp(var.cp))
+                    rule_logger.error("Invalid LGR: variant %s is not part of repertoire", format_cp(var.cp))
                     raise
 
                 rule_logger.debug("Variant %s", format_cp(var.cp))
@@ -2087,13 +2031,12 @@ class LGR(object):
                 else:
                     var_disp = frozenset([var.type])
 
-                if len(label) > len(char):
+                if len(label) > len(char) or len(variant) > len(var_char):
                     # Generate variants for reminder of label
                     for (perm_cps, perm_disp, perm_only_variants, perm_chars) in \
                             self._generate_variant_dispositions(label[len(char):],
                                                                 variant[len(var_char):],
-                                                                label_prefix=label_prefix + var.cp,
-                                                                has_variant=True):
+                                                                label_prefix=label_prefix + var.cp):
                         yield (var.cp + perm_cps,
                                # Construct new set of types
                                perm_disp | var_disp,
@@ -2102,7 +2045,7 @@ class LGR(object):
                 else:
                     yield var.cp, var_disp, True, [var]
 
-    def _apply_actions(self, label, disp_set, only_variants):
+    def _apply_actions(self, label, disp_set, only_variants) -> tuple[str | None, int]:
         """
         Apply the defined action of an LGR to a label and its dispositions.
 
@@ -2126,7 +2069,7 @@ class LGR(object):
                              action_list.index(action), action)
             disp = action.apply(label, disp_set, only_variants,
                                 self.rules_lookup, self.classes_lookup,
-                                self._unicode_database, )
+                                self._unicode_database)
             if disp is not None:
                 rule_logger.info("Action %d (%s) triggered",
                                  action_list.index(action),

--- a/lgr/core.py
+++ b/lgr/core.py
@@ -1303,11 +1303,10 @@ class LGR(object):
                     variant_disp = DEFAULT_DISPOSITION
 
             if (variant_disp != INVALID_DISPOSITION):
-                    yield variant_cp, variant_disp, variant_invalid_parts, idx, disp_set, log_output.getvalue(), chars
+                yield variant_cp, variant_disp, variant_invalid_parts, idx, disp_set, log_output.getvalue(), chars
 
             if collect_log:
                 rule_logger.removeHandler(ch)
-
 
     def estimate_variant_number(self, label, hide_mixed_script_variants=False):
         """

--- a/lgr/core.py
+++ b/lgr/core.py
@@ -1442,23 +1442,13 @@ class LGR:
         :return: A list of label partitions, as lists of chars. An empty list if label in invalid.
         """
         all_partitions = []
-        cp = label[0]
         prefix = prefix or ()
-        original_label = prefix + tuple(label)
 
-        try:
-            char_list = self.repertoire.get_chars_from_prefix(cp)
-        except NotInLGR:
-            return []
-
-        for char in char_list:
-            if not char.is_prefix_of(label):
-                continue
-            if not self._test_context_rules(char, original_label, len(prefix)):
-                # As per Root Zone Label Generation Rules (RZ LGR-6) Overview and Summary, section 5.5.4, step 2.b,
-                # "Further evaluation is skipped for any [partition] that have a code point context rule and do not
-                #  satisfy that rule for the input label at that location."
-                continue
+        # As per Root Zone Label Generation Rules (RZ LGR-6) Overview and Summary, section 5.5.4, step 2.b,
+        # "Further evaluation is skipped for any [partition] that have a code point context rule and do not
+        #  satisfy that rule for the input label at that location."
+        # This is done in _list_label_prefixes
+        for char in self._list_label_prefixes(label, prefix):
             if len(label) > len(char):
                 partitions = self._generate_label_partitions(label[len(char):], prefix=prefix + char.cp)
                 if not partitions:
@@ -1754,8 +1744,7 @@ class LGR:
 
         return self._apply_actions(label, disp_set, only_variants)
 
-    # TODO refactors other with this (see where we use get_chars_from_prefix)
-    def _get_prefix_list(self, label: Label, label_prefix: tuple[int]) -> LabelPartition:
+    def _get_prefix_list(self, label: Label, label_prefix: tuple[int]) -> list[CharBase]:
         """
         Generate the list of characters with same prefix.
 
@@ -1766,6 +1755,7 @@ class LGR:
         :param label: The label to generate the variants of.
         :param label_prefix: The prefix of the label.
         :return: list of valid prefix characters.
+        :raises: NotInLGR when no char or sequence begins with label's first cp
         """
         prefix_list = []
         for prefix in self.repertoire.get_chars_from_prefix(label[0]):
@@ -1930,26 +1920,17 @@ class LGR:
                 for (char_perm, disp, is_variant, chars) in char_perms:
                     yield char_perm.cp, disp, is_variant, [char_perm]
 
-    def _list_label_prefixes(self, label: Label, label_prefix: tuple[int]) -> LabelPartition:
+    def _list_label_prefixes(self, label: Label, label_prefix: tuple[int]) -> list[CharBase]:
         try:
             same_prefix = self._get_prefix_list(label, label_prefix)
         except NotInLGR:
-            rule_logger.debug('Char is not in LGR,'
-                              'assume we are handling a sequence')
+            rule_logger.debug('Char is not in LGR, assume we are handling a sequence')
             # This is not an error: we might be handling code points
             # belonging to a sequence which is being decomposed by the
             # variant generation process.
             # The sequence is part of the LGR,
             # but not the individual code points.
             same_prefix = []
-        else:
-            if len(same_prefix) == 0:
-                # No code point in LGR with variants,
-                # stick to first one found (longest in label)
-                for cp in self.repertoire.get_chars_from_prefix(label[0]):
-                    if cp.is_prefix_of(label):
-                        same_prefix = [cp]
-                        break
 
         return same_prefix
 

--- a/lgr/core.py
+++ b/lgr/core.py
@@ -1430,9 +1430,10 @@ class LGR(object):
         logger.debug("Computing index label for partition: %s", chars)
         index_label = []
         prefix = tuple()
-        suffix = tuple(c for cp in chars[1:] for c in cp.cp)
+        suffix = tuple(c for cp in chars for c in cp.cp)
         idx = 0
         for char in chars:
+            suffix = suffix[len(char):]
             logger.debug('Char CP: %s', format_cp(char.cp))
             # Index: smallest id of the char and its variants
             ids = [list(char.cp)]
@@ -1449,7 +1450,6 @@ class LGR(object):
             logger.debug('List of variant ids: %s', ids)
             index_label.extend(list(min(ids)))
             prefix += char.cp
-            suffix = suffix[len(char):]
             idx += len(char)
 
         logger.debug("Index label: '%s'", index_label)

--- a/lgr/core.py
+++ b/lgr/core.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from io import StringIO
 
 from lgr.action import Action
-from lgr.char import CharSequence, Repertoire
+from lgr.char import CharBase, CharSequence, Repertoire
 from lgr.classes import Class, TAG_CLASSNAME_PREFIX
 from lgr.exceptions import (LGRApiInvalidParameter,
                             CharAlreadyExists,
@@ -1056,13 +1056,7 @@ class LGR(object):
             rule_logger.addHandler(ch)
 
         # Start by testing presence of code points in LGR
-        chars = []
-        if generate_chars:
-            (valid, label_parts, label_invalid_parts, chars) = self._test_preliminary_eligibility(label,
-                                                                                                  generate_chars=generate_chars)
-        else:
-            (valid, label_parts, label_invalid_parts) = self._test_preliminary_eligibility(label,
-                                                                                           generate_chars=generate_chars)
+        (valid, label_parts, label_invalid_parts, chars) = self._test_preliminary_eligibility(label)
         if not valid:
             rule_logger.error("Label '%s' is not in the LGR", format_cp(label))
             if collect_log:
@@ -1326,7 +1320,7 @@ class LGR(object):
         :param hide_mixed_script_variants: Whether we count mixed scripts variants.
         :return: Estimated number of generated variants.
         """
-        (_, _, _, chars) = self._test_preliminary_eligibility(label, generate_chars=True)
+        (_, _, _, chars) = self._test_preliminary_eligibility(label)
         variant_number = 1
 
         def vars_excl_reflexive(current_char):
@@ -1382,7 +1376,7 @@ class LGR(object):
 
         logger.debug("Generating index label for '%s'", format_cp(label))
 
-        (result, _, not_in_lgr, _) = self._test_preliminary_eligibility(label, generate_chars=True)
+        (result, _, not_in_lgr, _) = self._test_preliminary_eligibility(label)
         if not result:
             logger.error('Label %s is not in LGR', format_cp(label))
             # If not result, there is at least on element in not_in_lgr.
@@ -1456,7 +1450,7 @@ class LGR(object):
 
         return tuple(index_label)
 
-    def _generate_label_partitions(self, label, prefix=None):
+    def _generate_label_partitions(self, label, prefix=None) -> list[list[CharBase]]:
         """
         Retrieve all partitions of a given label.
 
@@ -1583,7 +1577,7 @@ class LGR(object):
         logger.debug('Populate LGR variants')
         return populate_lgr(self)
 
-    def _test_preliminary_eligibility(self, label, generate_chars=False):
+    def _test_preliminary_eligibility(self, label: list[int]) -> tuple[bool, list[tuple[int]], list, list[CharBase]]:
         """
         Test label eligibility against an LGR.
 
@@ -1600,10 +1594,47 @@ class LGR(object):
                     * rule_specs: None if code point is not in the repertoire, list of rule names that does not comply
                                   for all characters starting with the code point.
                  * chars: List of the LGR chars included in label
-                          (only if generate_chars=True).
         :raises RuleError: If rule is invalid.
         """
         rule_logger.debug("Testing label '%s'", format_cp(label))
+
+        partitions = self._generate_label_partitions(label)
+        if partitions:
+            return self._retrieve_valid_label_parts(partitions)
+        else:
+            return self._retrieve_invalid_label_parts(label)
+
+    def _retrieve_valid_label_parts(self, partitions: list[list[CharBase]]) -> tuple[bool, list[tuple[int]], list, list[CharBase]]:
+        label_parts = []
+        chars = []
+
+        for char in partitions[0]:
+            rule_logger.debug("Code point '%s' in LGR", format_cp(char.cp))
+            label_parts += char.cp
+            chars.append(char)
+        return True, label_parts, [], chars
+
+    def _retrieve_invalid_label_parts(self, label) -> tuple[bool, list[tuple[int]], list, list[CharBase]]:
+        """
+        Extract valid and invalid parts from an invalid label.
+
+        Warning: this method does not go through all the possible paths, if multiple combinations exist with various
+        valid/invalid parts exits, only one is returned. That is because once a char is valid it goes to the next
+        without checking other prefixes.
+
+        :param label: The label to test, as an array of codepoints.
+        :param generate_chars: Return list of corresponding char objects.
+        :return: (result, label_parts, label_invalid_parts, chars), with:
+
+                 * result: True if the label is eligible according to the LGR,
+                           False otherwise.
+                 * label_parts: List of the code points valid in the LGR.
+                 * label_invalid_parts: List of (code point, rule_specs) not valid in the LGR, with:
+                    * rule_specs: None if code point is not in the repertoire, list of rule names that does not comply
+                                  for all characters starting with the code point.
+                 * chars: List of the LGR chars included in label
+        :raises RuleError: If rule is invalid.
+        """
         i = 0
         label_length = len(label)
 
@@ -1644,7 +1675,7 @@ class LGR(object):
 
                 i += len(char)
                 valid = True
-                rule_logger.debug("Code point '%s' in LGR", format_cp(cp))
+                rule_logger.debug("Code point '%s' in LGR", format_cp(char.cp))
                 label_parts += char.cp
                 chars.append(char)
                 break
@@ -1656,10 +1687,7 @@ class LGR(object):
                 label_invalid_parts.append((cp, pending_rules_not_in_lgr or None))
                 i += 1
 
-        if not generate_chars:
-            return result, label_parts, label_invalid_parts
-        else:
-            return result, label_parts, label_invalid_parts, chars
+        return result, label_parts, label_invalid_parts, chars if result else []
 
     def _test_label_disposition(self, label, apply_reflexive_mapping=True):
         """
@@ -2059,7 +2087,6 @@ class LGR(object):
                     var_disp = frozenset()
                 else:
                     var_disp = frozenset([var.type])
-
 
                 if len(label) > len(char):
                     # Generate variants for reminder of label

--- a/lgr/tools/annotate.py
+++ b/lgr/tools/annotate.py
@@ -32,8 +32,8 @@ def annotate(lgr, labels_input):
     for __, label, valid, error in read_labels(labels_input, lgr.unicode_database):
         if valid:
             label_cp = tuple([ord(c) for c in label])
-            (eligible, _, label_invalid_parts, disp, action_idx, _) = lgr.test_label_eligible(label_cp,
-                                                                                              collect_log=False)
+            (eligible, _, label_invalid_parts, disp, action_idx, _, _) = lgr.test_label_eligible(label_cp,
+                                                                                                 collect_log=False)
             for l in _out_valid_label(lgr, label, eligible, label_invalid_parts, disp, action_idx):
                 yield l
         else:
@@ -73,8 +73,8 @@ def lgr_set_annotate(lgr, script_lgr, set_labels_input, labels_input):
             label_cp = tuple([ord(c) for c in label])
             # First, verify that a proposed label is valid by processing it with the Element LGR
             # corresponding to the script that was selected for the label in the application.
-            (eligible, _, label_invalid_parts, disp, action_idx, _) = script_lgr.test_label_eligible(label_cp,
-                                                                                                     collect_log=False)
+            (eligible, _, label_invalid_parts, disp, action_idx, _, _) = script_lgr.test_label_eligible(label_cp,
+                                                                                                        collect_log=False)
             collision = ''
             if eligible:
                 # Second, process the now validated label against the common LGR to verify it does not collide

--- a/lgr/tools/diff_collisions.py
+++ b/lgr/tools/diff_collisions.py
@@ -110,7 +110,7 @@ def _generate_indexes(lgr, labels: List, tlds=None, keep=False, quiet=False, cac
                  variant_disp,
                  variant_invalid_parts,
                  action_idx, _,
-                 log) in lgr.compute_label_disposition(label_cp,
+                 log) in lgr.compute_label_disposition(label_cp,  # TODO replace with compute_variant_disposition in a loop when using with_labels
                                                        include_invalid=True,
                                                        collect_log=not quiet,
                                                        with_labels=[l['cp'] for l in primaries] if not keep else None):

--- a/lgr/tools/idn_review/whole_label_evaluation_rules.py
+++ b/lgr/tools/idn_review/whole_label_evaluation_rules.py
@@ -449,7 +449,7 @@ class WholeLabelEvaluationRulesCheck:
         return is_language
 
     def test_label(self, label):
-        result, a, b, c, d, e = self.idn_table.test_label_eligible(label)
+        result, _, _, _, _, _, _ = self.idn_table.test_label_eligible(label)
         return result
 
     def additional_cp_report(self) -> List[Dict]:

--- a/lgr/tools/utils.py
+++ b/lgr/tools/utils.py
@@ -393,8 +393,8 @@ class LgrToolArgParser(argparse.ArgumentParser):
         self.add_argument('-r', '--rng', metavar='RNG',
                           help='RelaxNG XML schema')
 
-    def add_xml_meta(self):
-        self.add_argument('xml', metavar='XML')
+    def add_xml_meta(self, help=''):
+        self.add_argument('xml', metavar='XML', help=help)
 
     def parse_args(self, *args, **kwargs):
         if not self.args:

--- a/tests/unit/test_lgr_core.py
+++ b/tests/unit/test_lgr_core.py
@@ -440,7 +440,6 @@ class TestLGRCore(unittest.TestCase):
         self.lgr.add_cp([0x0062])
         self.lgr.add_cp([0x0063])
 
-        a = self.lgr.get_char([0x0061])
         b = self.lgr.get_char([0x0062])
         c = self.lgr.get_char([0x0063])
 
@@ -482,15 +481,19 @@ class TestLGRCore(unittest.TestCase):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0062, 0x0063])
         self.lgr.add_range(0x0064, 0x0068)
+        a = self.lgr.get_char([0x0061])
+        bc = self.lgr.get_char([0x0062, 0x0063])
+        d = self.lgr.get_char(0x0064)
+        g = self.lgr.get_char(0x0068)
 
         valid_labels = (
-            [0x0061],
-            [0x0062, 0x0063],
-            [0x0064],
-            [0x0068],
-            [0x0061, 0x0064],
-            [0x0061, 0x0062, 0x0063, 0x0064],
-            [0x0062, 0x0063, 0x0068]
+            ([0x0061], [a]),
+            ([0x0062, 0x0063], [bc]),
+            ([0x0064], [d]),
+            ([0x0068], [g]),
+            ([0x0061, 0x0064], [a, d]),
+            ([0x0061, 0x0062, 0x0063, 0x0064], [a, bc, d]),
+            ([0x0062, 0x0063, 0x0068], [bc, g]),
         )
         invalid_labels = (
             ([0x0060], [], [(0x0060, None)]),
@@ -500,22 +503,39 @@ class TestLGRCore(unittest.TestCase):
             ([0x0061, 0x0062], [0x0061], [(0x0062, None)])
         )
 
-        for label in valid_labels:
-            self.assertEqual((True, label, []),
+        for label, chars in valid_labels:
+            self.assertEqual((True, label, [], chars),
                              self.lgr._test_preliminary_eligibility(label))
         for (label, label_part, not_in_lgr) in invalid_labels:
-            self.assertEqual((False, label_part, not_in_lgr),
+            self.assertEqual((False, label_part, not_in_lgr, []),
                              self.lgr._test_preliminary_eligibility(label))
 
     def test_label_eligibility_multiple_choices(self):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0061, 0x0062, 0x0063])
         self.lgr.add_cp([0x0064])
+        abc = self.lgr.get_char([0x0061, 0x0062, 0x0063])
+        d = self.lgr.get_char([0x0064])
 
         self.assertEqual(self.lgr._test_preliminary_eligibility([0x0062]),
-                         (False, [], [(0x0062, None)]))
+                         (False, [], [(0x0062, None)], []))
         self.assertEqual(self.lgr._test_preliminary_eligibility([0x0061, 0x0062, 0x0063, 0x0064]),
-                         (True, [0x0061, 0x0062, 0x0063, 0x0064], []))
+                         (True, [0x0061, 0x0062, 0x0063, 0x0064], [], [abc, d]))
+
+
+    def test_label_eligibility_invalid_code_point_in_sequence(self):
+        self.lgr.add_cp([0x0061])
+        self.lgr.add_cp([0x0065])
+        self.lgr.add_cp([0x006B])
+        self.lgr.add_cp([0x0061, 0x0065])
+        self.lgr.add_cp([0x0065, 0x0331])
+        a = self.lgr.get_char([0x0061])
+        k = self.lgr.get_char([0x006B])
+        e_ = self.lgr.get_char([0x0065, 0x0331])
+
+        self.assertEqual(self.lgr._test_preliminary_eligibility([0x0061, 0x0065, 0x0331, 0x006B]),
+                         (True, [0x0061, 0x0065, 0x0331, 0x006B], [], [a, e_, k]))
+
 
     def test_label_delayed_eligibilty(self):
         self.lgr.add_cp([0x0061])

--- a/tests/unit/test_lgr_core.py
+++ b/tests/unit/test_lgr_core.py
@@ -855,6 +855,27 @@ class TestLGRCore(unittest.TestCase):
         self.assertEqual((0x062, 0x0069, 0x0075, 0x0065),
                          self.lgr.generate_index_label([0x044B, 0x045F, 0x0435], max_recursion=1))
 
+    def test_generate_index_label_sequence_and_rule(self):
+        self.lgr.add_cp([0x092F])
+        self.lgr.add_cp([0x093E])
+        self.lgr.add_cp([0x093E, 0x093C])
+        self.lgr.add_cp([0x093C])
+        self.lgr.add_cp([0x0941])
+        self.lgr.add_cp([0x097B])
+
+        self.lgr.add_variant([0x093E], [0x093E, 0x093C], not_when='Deva--followed-by-N')
+        self.lgr.add_variant([0x093E, 0x093C], [0x093E], not_when='Deva--followed-by-N')
+
+        rule = Rule(name='Deva--followed-by-N')
+        rule.add_child(AnchorMatcher())
+        look = LookAheadMatcher()
+        look.add_child(CharMatcher((0x093C,)))
+        rule.add_child(look)
+        self.lgr.add_rule(rule)
+
+        self.assertEqual((0x092F, 0x0941, 0x097B, 0x093E),
+                         self.lgr.generate_index_label([0x092F, 0x0941, 0x097B, 0x093E, 0x093C]))
+
     def test_generate_variant_dispositions(self):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0062])
@@ -896,26 +917,58 @@ class TestLGRCore(unittest.TestCase):
             ((0x0070, 0x0072, 0x0072), frozenset(['type0', 'type2']), True, [p, r, r]),
         ], self.lgr._generate_variant_dispositions([0x0061, 0x0062, 0x0062], [0x0070, 0x0072, 0x0072]))
 
-    def test_generate_index_label_sequence_and_rule(self):
-        self.lgr.add_cp([0x092F])
-        self.lgr.add_cp([0x093E])
-        self.lgr.add_cp([0x093E, 0x093C])
-        self.lgr.add_cp([0x093C])
-        self.lgr.add_cp([0x0941])
-        self.lgr.add_cp([0x097B])
 
-        self.lgr.add_variant([0x093E], [0x093E, 0x093C], not_when='Deva--followed-by-N')
-        self.lgr.add_variant([0x093E, 0x093C], [0x093E], not_when='Deva--followed-by-N')
+    def test_generate_variant_dispositions_sequence(self):
+        self.lgr.add_cp([0x0061])
+        self.lgr.add_cp([0x0062])
+        self.lgr.add_cp([0x0063])
+        self.lgr.add_cp([0x0061, 0x0062])
+        self.lgr.add_cp([0x0062, 0x0062])
+        self.lgr.add_cp([0x0070])
+        self.lgr.add_cp([0x0071])
+        self.lgr.add_cp([0x0072])
 
-        rule = Rule(name='Deva--followed-by-N')
-        rule.add_child(AnchorMatcher())
-        look = LookAheadMatcher()
-        look.add_child(CharMatcher((0x093C,)))
-        rule.add_child(look)
-        self.lgr.add_rule(rule)
+        a = self.lgr.get_char([0x0061])
+        b = self.lgr.get_char([0x0062])
+        ab = self.lgr.get_char([0x0061, 0x0062])
+        bb = self.lgr.get_char([0x0062, 0x0062])
 
-        self.assertEqual((0x092F, 0x0941, 0x097B, 0x093E),
-                         self.lgr.generate_index_label([0x092F, 0x0941, 0x097B, 0x093E, 0x093C]))
+        self.lgr.add_variant([0x0061], [0x0070], variant_type="type0")
+        self.lgr.add_variant([0x0062], [0x0071], variant_type="type1")
+        self.lgr.add_variant([0x0061, 0x0062], [0x0070], variant_type="type2")
+        self.lgr.add_variant([0x0062, 0x0062], [0x0071], variant_type="type3")
+        self.lgr.add_variant([0x0070], [0x0061], variant_type="type5")
+        self.lgr.add_variant([0x0071], [0x0062], variant_type="type6")
+        self.lgr.add_variant([0x0070], [0x0061, 0x0062], variant_type="type7")
+        self.lgr.add_variant([0x0071], [0x0062, 0x0062], variant_type="type8")
+
+        p = a.get_variant((0x0070,))[0]
+        q = b.get_variant((0x0071,))[0]
+
+        self.assertCountEqual([
+            ((0x0070, 0x0071), frozenset(['type2', 'type1']), True, [p, q]),
+            ((0x0070, 0x0071), frozenset(['type3', 'type0']), True, [p, q]),
+        ], self.lgr._generate_variant_dispositions([0x0061, 0x0062, 0x0062], [0x0070, 0x0071]))
+        self.assertCountEqual([
+            ((0x0061, 0x0062, 0x0062), frozenset(['type7', 'type6']), True, [ab, b]),
+            ((0x0061, 0x0062, 0x0062), frozenset(['type5', 'type8']), True, [a, bb]),
+        ], self.lgr._generate_variant_dispositions([0x0070, 0x0071], [0x0061, 0x0062, 0x0062]))
+
+
+    def test_generate_variant_dispositions_reflexive(self):
+        self.lgr.add_cp([0x0061])
+        self.lgr.add_cp([0x0062])
+
+        a = self.lgr.get_char([0x0061])
+        b = self.lgr.get_char([0x0062])
+
+        self.lgr.add_variant([0x0061], [0x0061], variant_type="type0")
+
+        vara = a.get_variant((0x0061,))[0]
+
+        self.assertCountEqual([
+            ((0x0061, 0x0062, 0x0061), frozenset(['type0']), False, [vara, b, vara]),
+        ], self.lgr._generate_variant_dispositions([0x0061, 0x0062, 0x0061], [0x0061, 0x0062, 0x0061]))
 
 
 

--- a/tests/unit/test_lgr_core.py
+++ b/tests/unit/test_lgr_core.py
@@ -835,7 +835,6 @@ class TestLGRCore(unittest.TestCase):
         self.assertEqual((0x062, 0x0069, 0x0075, 0x0065),
                          self.lgr.generate_index_label([0x044B, 0x045F, 0x0435], max_recursion=1))
 
-
     def test_generate_variant_dispositions(self):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0062])
@@ -876,6 +875,28 @@ class TestLGRCore(unittest.TestCase):
         self.assertCountEqual([
             ((0x0070, 0x0072, 0x0072), frozenset(['type0', 'type2']), True, [p, r, r]),
         ], self.lgr._generate_variant_dispositions([0x0061, 0x0062, 0x0062], [0x0070, 0x0072, 0x0072]))
+
+    def test_generate_index_label_sequence_and_rule(self):
+        self.lgr.add_cp([0x092F])
+        self.lgr.add_cp([0x093E])
+        self.lgr.add_cp([0x093E, 0x093C])
+        self.lgr.add_cp([0x093C])
+        self.lgr.add_cp([0x0941])
+        self.lgr.add_cp([0x097B])
+
+        self.lgr.add_variant([0x093E], [0x093E, 0x093C], not_when='Deva--followed-by-N')
+        self.lgr.add_variant([0x093E, 0x093C], [0x093E], not_when='Deva--followed-by-N')
+
+        rule = Rule(name='Deva--followed-by-N')
+        rule.add_child(AnchorMatcher())
+        look = LookAheadMatcher()
+        look.add_child(CharMatcher((0x093C,)))
+        rule.add_child(look)
+        self.lgr.add_rule(rule)
+
+        self.assertEqual((0x092F, 0x0941, 0x097B, 0x093E),
+                         self.lgr.generate_index_label([0x092F, 0x0941, 0x097B, 0x093E, 0x093C]))
+
 
 
 if __name__ == '__main__':

--- a/tools/lgr_cli.py
+++ b/tools/lgr_cli.py
@@ -23,7 +23,7 @@ def check_label(lgr, label, invalid, test):
 
     logger.info("- Code points: %s", label_display)
 
-    (eligible, label_parts, label_invalid_parts, disp, action_idx, logs) = lgr.test_label_eligible(label_cp)
+    (eligible, label_parts, label_invalid_parts, disp, action_idx, logs, _) = lgr.test_label_eligible(label_cp)
     logger.info("- Eligible: %s", eligible)
     logger.info("- Disposition: %s", disp)
     is_default_action = action_idx > len(lgr.actions)

--- a/tools/lgr_collision.py
+++ b/tools/lgr_collision.py
@@ -35,8 +35,6 @@ def main():
     parser.add_common_args()
     parser.add_argument('-g', '--generate', action='store_true',
                         help='Generate variants')
-    parser.add_argument('-l', '--libs', metavar='LIBS',
-                        help='ICU libraries', required=True)
     parser.add_argument('-s', '--set', metavar='SET FILE',
                         help='Filepath to the set of reference labels',
                         required=True)

--- a/tools/lgr_index.py
+++ b/tools/lgr_index.py
@@ -1,0 +1,57 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+"""
+lgr_index.py - Small CLI tool to compute indexes on a list of labels
+"""
+import io
+import logging
+
+from lgr.exceptions import NotInLGR
+from lgr.tools.utils import write_output, LgrToolArgParser, read_labels
+from lgr.utils import format_cp
+
+logger = logging.getLogger("lgr_index")
+
+
+def main():
+    parser = LgrToolArgParser(description='LGR Collision')
+    parser.add_common_args()
+    parser.add_argument('-R', '--recursive', action='store_true',
+                        help='Compute recursive index')
+    parser.add_argument('-L', '--labels', metavar='LABELS',
+                        help='Filepath to the labels',
+                        required=True)
+    parser.add_xml_meta(help='Reference LGR for index computation')
+
+    args = parser.parse_args()
+
+    parser.setup_logger()
+
+    lgr = parser.parse_lgr()
+    if lgr is None:
+        logger.error("Error while parsing LGR file.")
+        logger.error("Please check compliance with RNG.")
+        return
+
+    with io.open(args.labels, 'r', encoding='utf-8') as labels_input:
+        for __, label, valid, error in read_labels(labels_input, lgr.unicode_database):
+            write_output('\n----------------------------------------------------\n')
+            if not valid:
+                write_output(f'{label}: {error}\n')
+                continue
+            label_cp = tuple([ord(c) for c in label])
+            write_output(f'Label {label} [{format_cp(label_cp)}]\n')
+            try:
+                label_partitions =  lgr._generate_label_partitions(label_cp)
+                write_output('Partitions:')
+                for partition in label_partitions:
+                    write_output('\t' + ' '.join(f'{{{format_cp(char.cp)}}}' for char in partition))
+                label_index = lgr.generate_index_label(label_cp, max_recursion=5 if args.recursive else 0)
+                write_output(f"Index: {format_cp(label_index)}")
+            except NotInLGR:
+                logger.warning('Label %s is not in LGR', label)
+                continue
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/lgr_validate.py
+++ b/tools/lgr_validate.py
@@ -41,7 +41,7 @@ def check_label(lgr, label, generate_variants=False, merged_lgr=None, set_labels
 
     write_output("\nLabel: %s [%s]" % (label, format_cp(label_cp)))
 
-    (eligible, label_parts, label_invalid_parts, disp, _, _) = lgr.test_label_eligible(label_cp, collect_log=False)
+    (eligible, label_parts, label_invalid_parts, disp, _, _, _) = lgr.test_label_eligible(label_cp, collect_log=False)
     write_output("\tEligible: %s" % eligible)
     write_output("\tDisposition: %s" % disp)
 


### PR DESCRIPTION
Add a method to compute a specific variant disposition without enumerating others
Add index computation tool
Various fixes on index computation, mainly with sequences