### PR TITLE
Feat/multi algo support

### DIFF
--- a/lgr/core.py
+++ b/lgr/core.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import collections
 import logging
 from collections import OrderedDict
+from enum import Enum
 from io import StringIO
 from typing import Optional, Iterator
 
@@ -35,7 +36,8 @@ from lgr.utils import (
     INHERITED_SCRIPT,
     collapse_codepoints,
     format_cp,
-    is_idna_valid_cp_or_sequence)
+    is_idna_valid_cp_or_sequence,
+    shortest_in_list)
 from lgr.validate import validate_lgr
 
 logger = logging.getLogger(__name__)
@@ -79,6 +81,13 @@ PROTOCOL_LABEL_MAX_LENGTH = 63
 Label = tuple[int] | list[int]
 InvalidLabelParts = list[tuple[int, None | list[str]]] | None
 LabelPartition = list[CharBase]
+
+class IndexComputationAlgorithm(Enum):
+    DEFAULT = 'default'
+    LESS_CHARS = 'less characters'
+    SHORTEST_INDEX = 'shortest index'
+    LONGEST_SEQUENCES = 'longest sequence'
+
 
 
 class LGR:
@@ -1326,7 +1335,7 @@ class LGR:
                 variant_number *= len(vars_excl_reflexive(char)) + 1  # Take into account original code point
         return variant_number
 
-    def generate_index_label(self, label: Label, max_recursion=0) -> tuple[int]:
+    def generate_index_label(self, label: Label, max_recursion=0, algo=IndexComputationAlgorithm.DEFAULT) -> tuple[int]:
         """
         Generate the "index label" of a given label.
 
@@ -1366,6 +1375,14 @@ class LGR:
         partitions = self._generate_label_partitions(label)
         logger.debug("%d partition(s) found", len(partitions))
 
+        if algo == IndexComputationAlgorithm.LESS_CHARS:
+            partitions = shortest_in_list(partitions)
+        elif algo == IndexComputationAlgorithm.LONGEST_SEQUENCES:
+            longest_seq = max(len(c.cp) for p in partitions for c in p)
+            partitions = [p for p in partitions if any(len(c.cp) == longest_seq for c in p)]
+            # also take the one with the fewer characters
+            partitions = shortest_in_list(partitions)
+
         indexes = []
         # We compute the index label for each partition then select the lowest in code point order
         # Most cases would work by only computing the happy path, but some edge cases would prevent this.
@@ -1373,6 +1390,9 @@ class LGR:
         # full computation would bring 'abc' which is lower in code point order.
         for partition in partitions:
             indexes.append(self._generate_index_label_on_partition(partition))
+
+        if algo == IndexComputationAlgorithm.SHORTEST_INDEX:
+            indexes = shortest_in_list(indexes)
 
         index_label = min(indexes)
         logger.debug("Index label: '%s'", index_label)
@@ -1383,7 +1403,7 @@ class LGR:
             # same computation ends up with a different index label
             old_index_label = tuple(index_label)
             try:
-                index_label = self.generate_index_label(index_label, max_recursion=max_recursion - 1)
+                index_label = self.generate_index_label(index_label, max_recursion=max_recursion - 1, algo=algo)
                 if index_label != old_index_label:
                     logger.warning("Index label '%s' changed to '%s' after a new itertion", old_index_label,
                                    index_label)
@@ -1421,6 +1441,7 @@ class LGR:
                     continue
                 ids.append(list(var.cp))
             logger.debug('List of variant ids: %s', ids)
+
             index_label.extend(list(min(ids)))
             prefix += char.cp
             idx += len(char)

--- a/lgr/core.py
+++ b/lgr/core.py
@@ -1083,7 +1083,7 @@ class LGR:
     def compute_label_disposition(self, label: tuple[int], include_invalid=False,
                                   collect_log=True, hide_mixed_script_variants=False,
                                   with_labels=None, generate_chars=False) -> Iterator[tuple[
-        tuple[int], str | None, InvalidLabelParts, int, set[str] | None, str, Optional[LabelPartition]]]:
+        tuple[int], str, InvalidLabelParts, int, set[str] | None, str, Optional[LabelPartition]]]:
         """
         Given a label, compute its disposition and its variants.
 
@@ -1174,7 +1174,7 @@ class LGR:
         yield original_label
 
     def _check_label_disp(self, label: Label, variant_cp: Label, disp_set: set[str], only_variants: bool,
-                          collect_log: bool) -> tuple[str | None, InvalidLabelParts, int, StringIO]:
+                          collect_log: bool) -> tuple[str, InvalidLabelParts, int, StringIO]:
         # Configure log system to redirect logs to local attribute
         log_output = StringIO()
         if collect_log:

--- a/lgr/parser/xml_parser.py
+++ b/lgr/parser/xml_parser.py
@@ -369,8 +369,11 @@ class XMLParser(LGRParser):
             self._parse_rule_helper(child, rule)
         
         if self._unicode_database:
-            rule.precalculate_patterns(self._lgr.rules_lookup, self._lgr.classes_lookup,
-                                    self._unicode_database)
+            try :
+                rule.precalculate_patterns(self._lgr.rules_lookup, self._lgr.classes_lookup,
+                                        self._unicode_database)
+            except Exception as e:
+                logger.warning("Cannot precompute patterns for rule %s: %s", rule.name, e)
 
         return rule
 

--- a/lgr/utils.py
+++ b/lgr/utils.py
@@ -5,6 +5,7 @@ utils.py - Set of utility functions to be used in module.
 from __future__ import unicode_literals
 
 import logging
+from typing import Iterable, List, Sized
 
 from language_tags import tags
 from pycountry import languages
@@ -242,6 +243,11 @@ def is_idna_valid_cp_or_sequence(cp_or_sequence, udata, check_all=False):
                 return False, all_invalid
     return len(all_invalid) == 0, all_invalid
 
+
+def shortest_in_list(list_of_list):
+    shortest_length = min(len(l) for l in list_of_list)
+    only_shortest = [s for s in list_of_list if len(s) == shortest_length]
+    return only_shortest
 
 if __name__ == "__main__":
     import doctest

--- a/tests/unit/test_lgr_core.py
+++ b/tests/unit/test_lgr_core.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import types
 import unittest
 
+from lgr.core import IndexComputationAlgorithm
 from lgr.char import Char, RangeChar
 from lgr.classes import TAG_CLASSNAME_PREFIX
 from lgr.core import LGR
@@ -522,7 +523,6 @@ class TestLGRCore(unittest.TestCase):
         self.assertEqual(self.lgr._test_preliminary_eligibility([0x0061, 0x0062, 0x0063, 0x0064]),
                          (True, [0x0061, 0x0062, 0x0063, 0x0064], [], [abc, d]))
 
-
     def test_label_eligibility_invalid_code_point_in_sequence(self):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0065])
@@ -535,7 +535,6 @@ class TestLGRCore(unittest.TestCase):
 
         self.assertEqual(self.lgr._test_preliminary_eligibility([0x0061, 0x0065, 0x0331, 0x006B]),
                          (True, [0x0061, 0x0065, 0x0331, 0x006B], [], [a, e_, k]))
-
 
     def test_label_delayed_eligibilty(self):
         self.lgr.add_cp([0x0061])
@@ -855,6 +854,105 @@ class TestLGRCore(unittest.TestCase):
         self.assertEqual((0x062, 0x0069, 0x0075, 0x0065),
                          self.lgr.generate_index_label([0x044B, 0x045F, 0x0435], max_recursion=1))
 
+
+    def test_generate_index_label_different_algos1(self):
+        self.lgr.add_cp([0x0061])
+        self.lgr.add_cp([0x0062])
+        self.lgr.add_cp([0x0063])
+        self.lgr.add_cp([0x0064])
+        self.lgr.add_cp([0x0065])
+        self.lgr.add_cp([0x0066])
+        self.lgr.add_cp([0x0067])
+        self.lgr.add_cp([0x0030])
+        self.lgr.add_cp([0x0031])
+        self.lgr.add_cp([0x0061, 0x0062, 0x0063])
+        self.lgr.add_cp([0x0062, 0x0063])
+        self.lgr.add_cp([0x0062, 0x0063, 0x0064, 0x0065])
+        self.lgr.add_cp([0x0064, 0x0065, 0x0066])
+
+        self.lgr.add_variant([0x0062, 0x0063], [0x0062])
+        self.lgr.add_variant([0x0062], [0x0062, 0x0063])
+        self.lgr.add_variant([0x0061, 0x0062, 0x0063], [0x0030])
+        self.lgr.add_variant([0x0030], [0x0061, 0x0062, 0x0063])
+        self.lgr.add_variant([0x0062, 0x0063, 0x0064, 0x0065], [0x0031])
+        self.lgr.add_variant([0x0031], [0x0062, 0x0063, 0x0064, 0x0065])
+        self.lgr.add_variant([0x0064, 0x0065, 0x0066], [0x0065])
+        self.lgr.add_variant([0x0065], [0x0064, 0x0065, 0x0066])
+
+        # partitions are {b}{c}{d} and {b,c}{d}, with possible indexes {b}{c}{d} and {b}{d}, however,
+        # {b}{c}{d} is lower in code point order
+        self.assertEqual((0x0062, 0x0063, 0x0064),
+                         self.lgr.generate_index_label([0x0062, 0x0063, 0x0064]))
+        # using non-default algorithm, {b,c}{d} is the partition with less char and longest char,
+        # and also has shortest index
+        for algo in [i for i in IndexComputationAlgorithm if i != IndexComputationAlgorithm.DEFAULT]:
+            self.assertEqual((0x0062, 0x0064),
+                             self.lgr.generate_index_label([0x0062, 0x0063, 0x0064],
+                                                           algo=algo))
+
+        # here partition for overall lowest index is {a b c}{d}{e}{f}{g},
+        # and lowest index is achieved when using variant {d e f} of {e}
+        self.assertEqual((0x0030, 0x0064, 0x0064, 0x0065, 0x0066, 0x0066, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.DEFAULT))
+        # here partition for less char is {a b c}{d e f}{g},
+        # and lowest index is {0}{d e f}{g}
+        self.assertEqual((0x0030, 0x0064, 0x0065, 0x0066, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.LESS_CHARS))
+        # longest sequence is {b c d e} with index {1}
+        self.assertEqual((0x0061, 0x0031, 0x0066, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.LONGEST_SEQUENCES))
+        # here we could expect {a b c}{d e f}{g} to end up with index {0}{e}{g}, but {e} is not an
+        # index for {d e f}, so we would actually get {0}{d e f}{g} which is not the shortest index
+        # shortest index is achieved with partition {a}{b c d e}{f}{g}
+        self.assertEqual((0x0061, 0x0031, 0x0066, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.SHORTEST_INDEX))
+
+    def test_generate_index_label_different_algos2(self):
+        self.lgr.add_cp([0x0061])
+        self.lgr.add_cp([0x0062])
+        self.lgr.add_cp([0x0063])
+        self.lgr.add_cp([0x0064])
+        self.lgr.add_cp([0x0065])
+        self.lgr.add_cp([0x0066])
+        self.lgr.add_cp([0x0067])
+        self.lgr.add_cp([0x0030])
+        self.lgr.add_cp([0x0031])
+        self.lgr.add_cp([0x0061, 0x0062, 0x0063])
+        self.lgr.add_cp([0x0062, 0x0063])
+        self.lgr.add_cp([0x0062, 0x0063, 0x0064, 0x0065])
+        self.lgr.add_cp([0x0064, 0x0065, 0x0066])
+
+        self.lgr.add_variant([0x0061, 0x0062, 0x0063], [0x0030])
+        self.lgr.add_variant([0x0030], [0x0061, 0x0062, 0x0063])
+        self.lgr.add_variant([0x0062, 0x0063, 0x0064, 0x0065], [0x0031])
+        self.lgr.add_variant([0x0031], [0x0062, 0x0063, 0x0064, 0x0065])
+        self.lgr.add_variant([0x0064, 0x0065, 0x0066], [0x0064])
+        self.lgr.add_variant([0x0064], [0x0064, 0x0065, 0x0066])
+
+        # here partition for overall lowest index is {a b c}{d}{e}{f}{g}
+        # since {d e f} would've ended with {0}{d}{g} which is greater than {0}{d}{e}{f}{g},
+        # and lowest index is therefore {0}{d}{e}{f}{g}
+        self.assertEqual((0x0030, 0x0064, 0x0065, 0x0066, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.DEFAULT))
+        # here partition for less char is {a b c}{d e f}{g},
+        # and lowest index is {0}{d}{g}
+        self.assertEqual((0x0030, 0x0064, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.LESS_CHARS))
+        # longest sequence is {b c d e} with index {1}
+        self.assertEqual((0x0061, 0x0031, 0x0066, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.LONGEST_SEQUENCES))
+        # in this case {a b c}{d e f}{g} gives the shortest index {0}{d}{g}
+        self.assertEqual((0x0030, 0x0064, 0x0067),
+                         self.lgr.generate_index_label([0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067],
+                                                       algo=IndexComputationAlgorithm.SHORTEST_INDEX))
+
     def test_generate_index_label_sequence_and_rule(self):
         self.lgr.add_cp([0x092F])
         self.lgr.add_cp([0x093E])
@@ -917,7 +1015,6 @@ class TestLGRCore(unittest.TestCase):
             ((0x0070, 0x0072, 0x0072), frozenset(['type0', 'type2']), True, [p, r, r]),
         ], self.lgr._generate_variant_dispositions([0x0061, 0x0062, 0x0062], [0x0070, 0x0072, 0x0072]))
 
-
     def test_generate_variant_dispositions_sequence(self):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0062])
@@ -954,7 +1051,6 @@ class TestLGRCore(unittest.TestCase):
             ((0x0061, 0x0062, 0x0062), frozenset(['type5', 'type8']), True, [a, bb]),
         ], self.lgr._generate_variant_dispositions([0x0070, 0x0071], [0x0061, 0x0062, 0x0062]))
 
-
     def test_generate_variant_dispositions_reflexive(self):
         self.lgr.add_cp([0x0061])
         self.lgr.add_cp([0x0062])
@@ -969,7 +1065,6 @@ class TestLGRCore(unittest.TestCase):
         self.assertCountEqual([
             ((0x0061, 0x0062, 0x0061), frozenset(['type0']), False, [vara, b, vara]),
         ], self.lgr._generate_variant_dispositions([0x0061, 0x0062, 0x0061], [0x0061, 0x0062, 0x0061]))
-
 
 
 if __name__ == '__main__':

--- a/tools/lgr_index.py
+++ b/tools/lgr_index.py
@@ -6,11 +6,44 @@ lgr_index.py - Small CLI tool to compute indexes on a list of labels
 import io
 import logging
 
+from lgr.core import IndexComputationAlgorithm
 from lgr.exceptions import NotInLGR
 from lgr.tools.utils import write_output, LgrToolArgParser, read_labels
 from lgr.utils import format_cp
 
 logger = logging.getLogger("lgr_index")
+
+
+def _index_algo_or_all(value):
+    try:
+        return [IndexComputationAlgorithm(value.replace('_', ' '))]
+    except ValueError:
+        pass
+
+    if value.lower() == 'all':
+        return list(IndexComputationAlgorithm)
+
+    raise ValueError(f'Invalid index computation algorithm: {value}')
+
+
+def display_label_index(args, lgr, label, valid, error):
+    write_output('\n----------------------------------------------------\n')
+    if not valid:
+        write_output(f'{label}: {error}\n')
+        return
+    label_cp = tuple([ord(c) for c in label])
+    write_output(f'Label {label} [{format_cp(label_cp)}]\n')
+    try:
+        label_partitions = lgr._generate_label_partitions(label_cp)
+        write_output('Partitions:')
+        for partition in label_partitions:
+            write_output('\t' + ' '.join(f'{{{format_cp(char.cp)}}}' for char in partition))
+        for algo in args.algorithm:
+            label_index = lgr.generate_index_label(label_cp, max_recursion=5 if args.recursive else 0,
+                                                   algo=algo)
+            write_output(f"Index {algo.value} algo:\t{'\t' if algo == IndexComputationAlgorithm.DEFAULT else ''}{format_cp(label_index)}")
+    except NotInLGR:
+        logger.warning('Label %s is not in LGR', label)
 
 
 def main():
@@ -21,6 +54,10 @@ def main():
     parser.add_argument('-L', '--labels', metavar='LABELS',
                         help='Filepath to the labels',
                         required=True)
+    parser.add_argument('-a', '--algorithm',
+                        type=_index_algo_or_all,
+                        default=[IndexComputationAlgorithm.DEFAULT],
+                        help='Index computation algorithm (default, shortest, lesser_chars, longest_sequences, all)')
     parser.add_xml_meta(help='Reference LGR for index computation')
 
     args = parser.parse_args()
@@ -35,22 +72,7 @@ def main():
 
     with io.open(args.labels, 'r', encoding='utf-8') as labels_input:
         for __, label, valid, error in read_labels(labels_input, lgr.unicode_database):
-            write_output('\n----------------------------------------------------\n')
-            if not valid:
-                write_output(f'{label}: {error}\n')
-                continue
-            label_cp = tuple([ord(c) for c in label])
-            write_output(f'Label {label} [{format_cp(label_cp)}]\n')
-            try:
-                label_partitions =  lgr._generate_label_partitions(label_cp)
-                write_output('Partitions:')
-                for partition in label_partitions:
-                    write_output('\t' + ' '.join(f'{{{format_cp(char.cp)}}}' for char in partition))
-                label_index = lgr.generate_index_label(label_cp, max_recursion=5 if args.recursive else 0)
-                write_output(f"Index: {format_cp(label_index)}")
-            except NotInLGR:
-                logger.warning('Label %s is not in LGR', label)
-                continue
+            display_label_index(args, lgr, label, valid, error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add support for various index computation algorithms and a tool that returns partitions and indexes for a list of label and a selected algorithm.
Default algorithm is kept unchanged